### PR TITLE
ci: pull latest changes from main before pushing coverage assets

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -54,12 +54,15 @@ jobs:
       - name: Generate Coverage Assets
         run: npm run generate-coverage-assets
 
+      - name: Pull latest changes
+        run: git pull origin main
+
       - name: Commit and Push Coverage Assets
         run: |
           git config user.name "GitHub Actions Bot"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add badges/*.svg badges/coverage-summary.png
           git commit -m "chore: update coverage badges and summary" || echo "No changes to commit"
-          git push
+          git push origin main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Added a step to pull the latest changes from the main before attempting to push coverage assets.